### PR TITLE
fix/subcommand parsed as non arg

### DIFF
--- a/src/main_command.ts
+++ b/src/main_command.ts
@@ -84,8 +84,7 @@ export class MainCommand extends Command {
 
     // If we get here, then the input did not match a subcommand. Therefore, we
     // pass the argument to the main command for further handling (if a handler
-    // method exists).
-    // If the input wasn't a subcommand, then let the main command take over
+    // method exists and if the argument is in the main command's signature).
     await this.handle();
     Deno.exit(0);
   }

--- a/src/subcommand.ts
+++ b/src/subcommand.ts
@@ -54,12 +54,11 @@ export class Subcommand extends Command {
    * Run this subcommand.
    */
   public async run(): Promise<void> {
-    let denoArgs = Deno.args.slice(); // Make a copy that we can mutate
-
-    // Remove the subcommand from the command line. We only care about the items
-    // that come after the subcommand.
-    const commandIndex = denoArgs.indexOf(this.name);
-    denoArgs = denoArgs.slice(commandIndex + 1, denoArgs.length);
+    const denoArgs = Deno.args.slice(); // Make a copy that we can mutate
+    // Remove the subcommand from the arg list because we only care about the
+    // arguments passed in. Everything after the subcommand should be options or
+    // arguments to the subcommand.
+    denoArgs.shift();
 
     const errors = super.validateDenoArgs(denoArgs);
 

--- a/tests/integration/duplicate_subcommands/cli.ts
+++ b/tests/integration/duplicate_subcommands/cli.ts
@@ -1,0 +1,32 @@
+import * as Line from "../../../mod.ts";
+
+class MainCommand extends Line.MainCommand {
+  public signature = "main";
+  public description = "The main command.";
+
+  public subcommands = [
+    Subcommand,
+  ];
+
+  public handle(): void {
+    console.log("Main command.");
+  }
+}
+
+class Subcommand extends Line.Subcommand {
+  public signature = "sub";
+  public description = "A subcommand.";
+
+  public handle() {
+    console.log("The subcommand.");
+  }
+}
+
+const cli = new Line.CLI({
+  name: "A main command with a subcommand.",
+  description: "Subcommands cannot be written twice.",
+  version: "v1.0.0",
+  command: MainCommand,
+});
+
+cli.run();

--- a/tests/integration/duplicate_subcommands/cli_test.ts
+++ b/tests/integration/duplicate_subcommands/cli_test.ts
@@ -1,0 +1,78 @@
+import { asserts } from "../../deps.ts";
+import {
+  assertOutput as assertOutputHelper,
+  run as runHelper,
+} from "../integration_test_helper.ts";
+
+export async function run(command?: string) {
+  if (command) {
+    command = command.replace(
+      /\{path\}/g,
+      "tests/integration/duplicate_subcommands/expected_outputs/",
+    );
+  }
+
+  command = command ? " " + command : "";
+
+  const fullCommand =
+    `deno run --allow-read --allow-write tests/integration/duplicate_subcommands/cli.ts${command}`;
+
+  const stdout = await runHelper(fullCommand);
+
+  return stdout.trim();
+}
+
+export function assertOutput(actual: string, expectedFile: string) {
+  assertOutputHelper(
+    actual,
+    expectedFile,
+    false,
+    "tests/integration/duplicate_subcommands/expected_outputs/" + expectedFile,
+  );
+}
+
+// Main command
+
+Deno.test("should show help menu: (no arguments provided)", async () => {
+  const stdout = await run();
+  assertOutput(stdout, "help.txt");
+});
+
+Deno.test("should show help menu: --help", async () => {
+  const stdout = await run("--help");
+  assertOutput(stdout, "help.txt");
+});
+
+Deno.test("should show help menu: -h", async () => {
+  const stdout = await run("-h");
+  assertOutput(stdout, "help.txt");
+});
+
+Deno.test("should show version: --version", async () => {
+  const stdout = await run("--version");
+  assertOutput(stdout, "version.txt");
+});
+
+Deno.test("should show version: -v", async () => {
+  const stdout = await run("-v");
+  assertOutput(stdout, "version.txt");
+});
+
+// If a handle method is on the main command, then let it handle all unknown
+// items in Deno.args
+Deno.test("should let main command handle arguments: main", async () => {
+  const stdout = await run("main");
+  assertOutput(stdout, "main_throws_unknown_argument_error.txt");
+});
+
+// Duplicate subcommand in `Deno.args` should be counted as an arg
+
+Deno.test("should execute the subcommand: sub", async () => {
+  const stdout = await run("sub");
+  assertOutput(stdout, "sub_runs_handle_method.txt");
+});
+
+Deno.test("should throw an argument error: sub sub", async () => {
+  const stdout = await run("sub sub");
+  assertOutput(stdout, "sub_throws_argment_error.txt");
+});

--- a/tests/integration/duplicate_subcommands/expected_outputs/help.txt
+++ b/tests/integration/duplicate_subcommands/expected_outputs/help.txt
@@ -1,0 +1,18 @@
+A main command with a subcommand. - Subcommands cannot be written twice.
+
+USAGE
+
+    main [option]
+    main [subcommand]
+
+SUBCOMMANDS
+
+    sub
+        A subcommand.
+
+OPTIONS
+
+    -h, --help
+        Show this menu.
+    -v, --version
+        Show this CLI's version.

--- a/tests/integration/duplicate_subcommands/expected_outputs/main_throws_unknown_argument_error.txt
+++ b/tests/integration/duplicate_subcommands/expected_outputs/main_throws_unknown_argument_error.txt
@@ -1,0 +1,10 @@
+[31m[ERROR] [39mCommand 'main' used incorrectly. Error(s) found:
+
+  * Unknown argument(s) provided: main.
+
+USAGE
+
+    main [option]
+    main [subcommand]
+
+    Run `main --help` for more information.

--- a/tests/integration/duplicate_subcommands/expected_outputs/sub_runs_handle_method.txt
+++ b/tests/integration/duplicate_subcommands/expected_outputs/sub_runs_handle_method.txt
@@ -1,0 +1,1 @@
+The subcommand.

--- a/tests/integration/duplicate_subcommands/expected_outputs/sub_throws_argment_error.txt
+++ b/tests/integration/duplicate_subcommands/expected_outputs/sub_throws_argment_error.txt
@@ -1,0 +1,10 @@
+[31m[ERROR] [39mSubcommand 'sub' used incorrectly. Error(s) found:
+
+  * Unknown argument(s) provided: sub.
+
+USAGE (for: `main sub`)
+
+    main sub [option]
+    main sub [options] 
+
+    Run `main sub --help` for more information.

--- a/tests/integration/duplicate_subcommands/expected_outputs/version.txt
+++ b/tests/integration/duplicate_subcommands/expected_outputs/version.txt
@@ -1,0 +1,1 @@
+A main command with a subcommand. v1.0.0


### PR DESCRIPTION
@dXu23 , those lines you removed did need to be removed, so thank you for that! this PR adds tests for the issue and ensures that the first item in `Deno.args` is shifted off if the main command runs subcommands. 

Reason I added `.shift()` is because it seems to be the more robust way instead of checking the index of a subcommand and then slicing it out.